### PR TITLE
Fix persistent MPP_ENC_GET_EXTRA_INFO safety warnings with HDR_SYNC migration

### DIFF
--- a/scripts/build_mpp.sh
+++ b/scripts/build_mpp.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/bash
 CURRENT_DIR=$(pwd)
-MPP_VERSION=1.0.5
+MPP_VERSION=1.0.6
 MPP_SRC=mpp-${MPP_VERSION}
 MPP_SRC_DIR=${CURRENT_DIR}/thirdparty/${MPP_SRC}
 MPP_URL=https://github.com/rockchip-linux/mpp/archive/refs/tags/${MPP_VERSION}.tar.gz

--- a/src/RkEncoder.cc
+++ b/src/RkEncoder.cc
@@ -146,17 +146,32 @@ int RkEncoder::encode(void *inbuf, int insize, uint8_t *outbuf)
         return -1;
     }
 
-    MppPacket m_extra_info;
-    ret = m_mpi->control(m_contex, MPP_ENC_GET_EXTRA_INFO, &m_extra_info);
-    if (ret) {
-        LOG(ERROR, "mpi control enc get extra info failed");
+    MppPacket m_extra_info = NULL;
+    MppBuffer buffer = NULL;
+    size_t size = 1024;
+
+    mpp_buffer_get(NULL, &buffer, size);
+    mpp_packet_init_with_buffer(&m_extra_info, buffer);
+
+    mpp_packet_set_length(m_extra_info, 0);
+
+    ret = m_mpi->control(m_contex, MPP_ENC_GET_HDR_SYNC, m_extra_info);
+    if (ret)
+    {
+        LOG(ERROR, "mpi control enc get header sync failed");
+        mpp_packet_deinit(&m_extra_info);
+        if (buffer)
+            mpp_buffer_put(buffer);
         return -1;
     }
 
     void *ptr_extra_info = mpp_packet_get_data(m_extra_info);
     size_t len_extra_info = mpp_packet_get_length(m_extra_info);
     memcpy(outbuf, ptr_extra_info, len_extra_info);
+
     mpp_packet_deinit(&m_extra_info);
+    if (buffer)
+        mpp_buffer_put(buffer);
 
     void *ptr_video_data = mpp_packet_get_data(m_packet);
     size_t len_video_data = mpp_packet_get_length(m_packet);


### PR DESCRIPTION
Issue Context
The original MPP_ENC_GET_EXTRA_INFO interface triggers continuous runtime warnings during execution:

mpp[493881]: mpp_enc: Please use MPP_ENC_GET_HDR_SYNC instead of unsafe MPP_ENC_GET_EXTRA_INFO  
mpp[493881]: mpp_enc: NOTE: MPP_ENC_GET_HDR_SYNC needs MppPacket input  

These warnings indicate that the deprecated interface poses potential safety risks and disrupts clean runtime logging.

Solution
Replaced all instances of MPP_ENC_GET_EXTRA_INFO with the recommended MPP_ENC_GET_HDR_SYNC

Ensured compliance with the new interface's requirement for MppPacket input

Testing
Environment:

Device: RK3588

OS: Ubuntu 20.04

MPP Version: Confirmed compatible with the updated interface

Result:

No more safety warnings observed during runtime

Core functionality (video encoding/streaming) operates as expected